### PR TITLE
Support non-IOMMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,6 @@ is `enp216s0f0` and the IP address is `192.168.1.10`.
 
 ## Known Issues
 
-### IOMMU
-
-IOMMU is required to make the driver work.  To enable IOMMU, first check the
-BIOS settings to make sure that it is enabled.  If the CPU is an Intel processor, add 
-`intel_iommu=on` to the boot parameters.  No changes are necessary for AMD processors. Run 
-`update-grub` and reboot the server.
-
 ### Static IP Address
 
 It has been found that in some cases, DHCP clients may cause kernel panic after

--- a/onic_main.c
+++ b/onic_main.c
@@ -156,7 +156,7 @@ static int onic_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 		dev_err(&pdev->dev, "Failed to set DMA masks");
 		goto disable_device;
 	} else {
-		dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 	}
 
 	rv = pci_request_mem_regions(pdev, onic_drv_name);


### PR DESCRIPTION
The driver was wrongly setting up streaming mappings to a 32-bit
DMA mask. Only coherent mask should be 32 bit. This fixes non-IOMMU
systems.

Signed-off-by: Lars Munch <lars@segv.dk>