### PR TITLE
RFC: Refactor interrupts

### DIFF
--- a/onic.h
+++ b/onic.h
@@ -25,11 +25,14 @@
 #define ONIC_MAX_QUEUES			64
 
 /* state bits */
-#define ONIC_ERROR_INTR			0
+#define ONIC_MBOX_INTR			0
 #define ONIC_USER_INTR			1
+#define ONIC_ERROR_INTR			2
 
 /* flag bits */
 #define ONIC_FLAG_MASTER_PF		0
+#define ONIC_FLAG_MBOX_INTR		1
+#define ONIC_FLAG_USER_INTR		2
 
 struct onic_tx_buffer {
 	struct sk_buff *skb;
@@ -81,6 +84,7 @@ struct onic_rx_queue {
 };
 
 struct onic_q_vector {
+	u16 qid;
 	u16 vid;
 	struct onic_private *priv;
 	struct cpumask affinity_mask;


### PR DESCRIPTION
Currently the vector ID and queue ID are the same and the ID starts a 0. User
interrupt are allocated after queue interrupts. This results in the user
interrupt ending up at different locations depending on the number of vectors
available in the system. This is a problem as the user interrupt vector is
hardcoded in the shell and not configurable from SW.

This patch reorders the interrupt such that it matches the QDMA reference
driver:

0. mailbox interrupt (optional - defaults to unused)
1. user interrupt (optional - defaults to unused)
2. error interrupt on PF0
3. queue 0 interrupt
4. queue 1 interrupt
...

Hence, if mailbox interrupts is disabled, user interrupt will end up a interrupt
vector 0 and if enabled at interrupt vector 1.

Signed-off-by: Lars Munch <lars@segv.dk>