### PR TITLE
Driver changes needed to get U55C working with networking hardware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,13 @@
 # 
 # The full GNU General Public License is included in this distribution in
 # the file called "COPYING".
-# 
+#
+ifdef KVERSION
+KERNEL_VERS = $(KVERSION)
+else
+KERNEL_VERS = $(shell uname -r)
+endif
+
 srcdir = $(PWD)
 obj-m += onic.o
 BASE_OBJS := $(patsubst $(srcdir)/%.c,%.o,$(wildcard $(srcdir)/*.c $(srcdir)/*/*.c $(srcdir)/*/*/*.c))
@@ -22,7 +28,17 @@ ccflags-y = -O3 -Wall -Werror -I$(srcdir)/qdma_access -I$(srcdir)
 
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
 	rm -f *.o.ur-safe
 	rm -f ./qdma_access/*.o.ur-safe
+
+install:
+	rm -f /lib/modules/$(KERNEL_VERS)/onic.ko
+	cp onic.ko /lib/modules/$(KERNEL_VERS)
+	depmod
+
+uninstall:
+	rm -f /lib/modules/$(KERNEL_VERS)/onic.ko
+	depmod


### PR DESCRIPTION
I've had a great deal of difficulty getting a Xilinx U55C + stock onic driver to link and communicate when attached to various Cisco switches.  After a bunch of experimentation I figured out the issues.  This PR contains those changes along with a few minor improvements.

- Revert changes from 90c98b6580b6e050cd27a003c672494577803044; the alignment check and wait is necessary for any non-loopback use case. 
- Increase the alignment check wait time to 1000ms. 
- Add install and uninstall targets to the Makefile. 
- Add custom ethtool `onic_get_link()` function that actually reads the STAT_RX_STATUS CMAC register to determine if the CMAC has link.