### PR TITLE
Update to the latest Ubuntu 22.04.3 LTS

### DIFF
--- a/onic_netdev.c
+++ b/onic_netdev.c
@@ -553,7 +553,11 @@ static int onic_init_rx_queue(struct onic_private *priv, u16 qid)
 	ring->next_to_clean = 0;
 	ring->color = 1;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
+	netif_napi_add(dev, &q->napi, onic_rx_poll);
+#else
 	netif_napi_add(dev, &q->napi, onic_rx_poll, 64);
+#endif
 	napi_enable(&q->napi);
 
 	/* initialize QDMA C2H queue */


### PR DESCRIPTION
This PR updates the driver to compile with the latest Ubuntu 22.04.3 LTS. 

The parameters of `netif_napi_add()` have been changed in the recent kernel versions. From kernel version 6.1 `int weight` is not a part of the `netif_napi_add() `API anymore but is set as a default one:

https://elixir.bootlin.com/linux/v6.1/source/include/linux/netdevice.h#L2562
https://elixir.bootlin.com/linux/v6.1/source/include/linux/netdevice.h#L2547

The latest version with the old API: 6.0.19
https://elixir.bootlin.com/linux/v6.0.19/source/include/linux/netdevice.h#L2567

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.3 LTS
Release:    22.04
Codename:   jammy

$ uname -r
6.2.0-31-generic
```
`insmod` and `dmesg` show no errors. However, I can not test the changes in hardware. 