### PR TITLE
Fix warnings for kernel version 5.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,13 @@ BASE_OBJS := $(patsubst $(srcdir)/%.c,%.o,$(wildcard $(srcdir)/*.c $(srcdir)/*/*
 onic-objs = $(BASE_OBJS)
 ccflags-y = -O3 -Wall -Werror -I$(srcdir)/qdma_access -I$(srcdir)/hwmon -I$(srcdir)
 
+KDIR ?= /lib/modules/$(shell uname -r)/build
+
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C $(KDIR) M=$(PWD) modules
 	
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C $(KDIR) M=$(PWD) clean
 	rm -f *.o.ur-safe
 	rm -f ./qdma_access/*.o.ur-safe
 

--- a/onic_lib.c
+++ b/onic_lib.c
@@ -23,8 +23,6 @@
 
 extern int onic_poll(struct napi_struct *napi, int budget);
 
-static const enum qdma_intr_rngsz intr_rngsz = QDMA_INTR_RNGSZ_4KB;
-
 static irqreturn_t onic_q_handler(int irq, void *dev_id)
 {
 	struct onic_q_vector *vec = dev_id;


### PR DESCRIPTION
Primarily moving to eth_hw_addr_set from netdev addr memcpy to be able to build on kernel version 5.19.
Fixing other unused variables and const causing warnings.