### PR TITLE
Fix to compile on linux kernel 6.4: Rename FIELD_GET to BITFIELD_GET

### DIFF
--- a/onic_common.h
+++ b/onic_common.h
@@ -61,7 +61,7 @@ static inline u8 get_trailing_zeros(u64 x)
 
 #define FIELD_SHIFT(mask)	get_trailing_zeros(mask)
 #define FIELD_SET(mask, val)	(((u64)(val) << FIELD_SHIFT(mask)) & mask)
-#define FIELD_GET(mask, reg)	((reg & mask) >> FIELD_SHIFT(mask))
+#define BITFIELD_GET(mask, reg)	((reg & mask) >> FIELD_SHIFT(mask))
 
 /**
  * print_raw_data - print raw data to kernel log

--- a/qdma_access/qdma_context.c
+++ b/qdma_access/qdma_context.c
@@ -122,9 +122,9 @@ int qdma_write_sw_ctxt(struct qdma_dev *qdev, u16 qid, enum qdma_dir dir,
 	cmd.bits.op = QDMA_CTXT_CMD_OP_WR;
 	cmd.bits.qid = qdma_get_real_qid(qdev, qid);
 
-	desc_base_l = (u32)FIELD_GET(QDMA_SW_CTXT_DESC_BASE_GET_L_MASK,
+	desc_base_l = (u32)BITFIELD_GET(QDMA_SW_CTXT_DESC_BASE_GET_L_MASK,
 				     ctxt->desc_base);
-	desc_base_h = (u32)FIELD_GET(QDMA_SW_CTXT_DESC_BASE_GET_H_MASK,
+	desc_base_h = (u32)BITFIELD_GET(QDMA_SW_CTXT_DESC_BASE_GET_H_MASK,
 				     ctxt->desc_base);
 
 	data[num_words++] =
@@ -256,9 +256,9 @@ int qdma_write_pfch_ctxt(struct qdma_dev *qdev, u16 qid,
 	cmd.bits.op = QDMA_CTXT_CMD_OP_WR;
 	cmd.bits.qid = qdma_get_real_qid(qdev, qid);
 
-	sw_crdt_l = (u32)FIELD_GET(QDMA_PFCH_CTXT_SW_CRDT_GET_L_MASK,
+	sw_crdt_l = (u32)BITFIELD_GET(QDMA_PFCH_CTXT_SW_CRDT_GET_L_MASK,
 				   ctxt->sw_crdt);
-	sw_crdt_h = (u32)FIELD_GET(QDMA_PFCH_CTXT_SW_CRDT_GET_H_MASK,
+	sw_crdt_h = (u32)BITFIELD_GET(QDMA_PFCH_CTXT_SW_CRDT_GET_H_MASK,
 				   ctxt->sw_crdt);
 
 	data[num_words++] =
@@ -316,13 +316,13 @@ int qdma_write_cmpl_ctxt(struct qdma_dev *qdev, u16 qid,
 	cmd.bits.op = QDMA_CTXT_CMD_OP_WR;
 	cmd.bits.qid = qdma_get_real_qid(qdev, qid);
 
-	baddr_l = (u32)FIELD_GET(QDMA_CMPL_CTXT_BADDR_GET_L_MASK,
+	baddr_l = (u32)BITFIELD_GET(QDMA_CMPL_CTXT_BADDR_GET_L_MASK,
 				 ctxt->baddr);
-	baddr_h = (u32)FIELD_GET(QDMA_CMPL_CTXT_BADDR_GET_H_MASK,
+	baddr_h = (u32)BITFIELD_GET(QDMA_CMPL_CTXT_BADDR_GET_H_MASK,
 				 ctxt->baddr);
-	pidx_l = (u32)FIELD_GET(QDMA_CMPL_CTXT_PIDX_GET_L_MASK,
+	pidx_l = (u32)BITFIELD_GET(QDMA_CMPL_CTXT_PIDX_GET_L_MASK,
 				ctxt->pidx);
-	pidx_h = (u32)FIELD_GET(QDMA_CMPL_CTXT_PIDX_GET_H_MASK,
+	pidx_h = (u32)BITFIELD_GET(QDMA_CMPL_CTXT_PIDX_GET_H_MASK,
 				ctxt->pidx);
 
 	data[num_words++] =

--- a/qdma_access/qdma_export.c
+++ b/qdma_access/qdma_export.c
@@ -54,8 +54,8 @@ void qdma_unpack_wb_stat(struct qdma_wb_stat *stat, u8 *data)
 
 	dw = (u64 *)data;
 
-	stat->pidx = FIELD_GET(QDMA_WB_STAT_DW_PIDX_MASK, *dw);
-	stat->cidx = FIELD_GET(QDMA_WB_STAT_DW_CIDX_MASK, *dw);
+	stat->pidx = BITFIELD_GET(QDMA_WB_STAT_DW_PIDX_MASK, *dw);
+	stat->cidx = BITFIELD_GET(QDMA_WB_STAT_DW_CIDX_MASK, *dw);
 }
 
 void qdma_unpack_c2h_cmpl(struct qdma_c2h_cmpl *cmpl, u8 *data)
@@ -67,10 +67,10 @@ void qdma_unpack_c2h_cmpl(struct qdma_c2h_cmpl *cmpl, u8 *data)
 
 	dw = (u64 *)data;
 
-	cmpl->color = FIELD_GET(QDMA_C2H_CMPL_DW_COLOR_MASK, *dw);
-	cmpl->err = FIELD_GET(QDMA_C2H_CMPL_DW_ERR_MASK, *dw);
-	cmpl->pkt_len = FIELD_GET(QDMA_C2H_CMPL_DW_PKT_LEN_MASK, *dw);
-	cmpl->pkt_id = FIELD_GET(QDMA_C2H_CMPL_DW_PKT_ID_MASK, *dw);
+	cmpl->color = BITFIELD_GET(QDMA_C2H_CMPL_DW_COLOR_MASK, *dw);
+	cmpl->err = BITFIELD_GET(QDMA_C2H_CMPL_DW_ERR_MASK, *dw);
+	cmpl->pkt_len = BITFIELD_GET(QDMA_C2H_CMPL_DW_PKT_LEN_MASK, *dw);
+	cmpl->pkt_id = BITFIELD_GET(QDMA_C2H_CMPL_DW_PKT_ID_MASK, *dw);
 }
 
 void qdma_unpack_c2h_cmpl_stat(struct qdma_c2h_cmpl_stat *stat, u8 *data)
@@ -82,9 +82,9 @@ void qdma_unpack_c2h_cmpl_stat(struct qdma_c2h_cmpl_stat *stat, u8 *data)
 
 	dw = (u64 *)data;
 
-	stat->pidx = FIELD_GET(QDMA_C2H_CMPL_STAT_DW_PIDX_MASK, *dw);
-	stat->cidx = FIELD_GET(QDMA_C2H_CMPL_STAT_DW_CIDX_MASK, *dw);
-	stat->color = FIELD_GET(QDMA_C2H_CMPL_STAT_DW_COLOR_MASK, *dw);
+	stat->pidx = BITFIELD_GET(QDMA_C2H_CMPL_STAT_DW_PIDX_MASK, *dw);
+	stat->cidx = BITFIELD_GET(QDMA_C2H_CMPL_STAT_DW_CIDX_MASK, *dw);
+	stat->color = BITFIELD_GET(QDMA_C2H_CMPL_STAT_DW_COLOR_MASK, *dw);
 	stat->intr_state =
-		FIELD_GET(QDMA_C2H_CMPL_STAT_DW_INTR_STATE_MASK, *dw);
+		BITFIELD_GET(QDMA_C2H_CMPL_STAT_DW_INTR_STATE_MASK, *dw);
 }


### PR DESCRIPTION
The macro `FIELD_GET` is already defined in `linux/bitfield.h`, that is somehow included when compiling the onic driver on linux 6.4. This causes the following error:

```
open-nic-driver/onic_common.h:64: error: "FIELD_GET" redefined [-Werror]
   64 | #define FIELD_GET(mask, reg)    ((reg & mask) >> FIELD_SHIFT(mask))
```

Unfortunately, the `FIELD_GET` macro that is already defined in `linux/bitfield.h` is using the `typeof` operator, and the `typeof` operator cannot be applied to bit-field members:
* https://en.cppreference.com/w/cpp/language/bit_field
* https://en.cppreference.com/w/c/language/typeof

The onic driver is making heavy use of bit-fields, thus, we cannot use the already defined `FIELD_GET` macro without a heavy code refactoring.

This commit simply renames the `FIELD_GET` macro defined in the onic driver to `BITFIELD_GET` to avoid the macro redefinition error.