### PR TITLE
Fixes to compile with clang on linux 6.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ KDIR ?= /lib/modules/$(shell uname -r)/build
 
 all:
 	make -C $(KDIR) M=$(PWD) modules
+
+with-clang:
+	make CC=clang -C $(KDIR) M=$(PWD) modules
 	
 clean:
 	make -C $(KDIR) M=$(PWD) clean

--- a/hwmon/xocl_ctx.c
+++ b/hwmon/xocl_ctx.c
@@ -183,7 +183,7 @@ int xocl_drvinst_set_offline(void *data, bool offline)
 failed:
 	mutex_unlock(&xocl_drvinst_lock);
 
-	return 0;
+	return ret;
 }
 
 int xocl_drvinst_get_offline(void *data, bool *offline)

--- a/hwmon/xocl_debug.c
+++ b/hwmon/xocl_debug.c
@@ -67,7 +67,7 @@ static struct xocl_debug xrt_debug = {
 
 static unsigned long global_mod;
 
-static int trace_open(struct inode *inode, struct file *file)
+static inline int trace_open(struct inode *inode, struct file *file)
 {
 	spin_lock(&xrt_debug.trace_lock);
 	xrt_debug.overrun = 0;
@@ -79,12 +79,12 @@ static int trace_open(struct inode *inode, struct file *file)
 	return 0;
 }
 
-static int trace_release(struct inode *inode, struct file *file)
+static inline int trace_release(struct inode *inode, struct file *file)
 {
 	return 0;
 }
 
-static ssize_t trace_read(struct file *file, char __user *buf,
+static inline ssize_t trace_read(struct file *file, char __user *buf,
 			  size_t sz, loff_t *ppos)
 {
 	ssize_t count = 0;
@@ -140,15 +140,7 @@ out:
 	return count;
 }
 
-static const struct file_operations trace_fops = {
-	.owner = THIS_MODULE,
-	.open = trace_open,
-	.release = trace_release,
-	.read = trace_read,
-	.llseek = no_llseek,
-};
-
-static ssize_t trace_mod_read(struct file *file, char __user *buf,
+static inline ssize_t trace_mod_read(struct file *file, char __user *buf,
 			      size_t sz, loff_t *ppos)
 {
 	struct xrt_debug_mod *mod;
@@ -194,7 +186,7 @@ static ssize_t trace_mod_read(struct file *file, char __user *buf,
 }
 
 
-static ssize_t trace_mod_write(struct file *filp, const char __user *data,
+static inline ssize_t trace_mod_write(struct file *filp, const char __user *data,
 				size_t data_len, loff_t *ppos)
 {
 	struct xrt_debug_mod *mod = NULL, *_mod;
@@ -239,12 +231,6 @@ fail:
 	mutex_unlock(&xrt_debug.mod_lock);
 	return -EINVAL;
 }
-
-static const struct file_operations trace_mod_fops = {
-	.owner = THIS_MODULE,
-	.read = trace_mod_read,
-	.write = trace_mod_write,
-};
 
 void xocl_debug_fini(void)
 {

--- a/onic_common.h
+++ b/onic_common.h
@@ -61,7 +61,7 @@ static inline u8 get_trailing_zeros(u64 x)
 
 #define FIELD_SHIFT(mask)	get_trailing_zeros(mask)
 #define FIELD_SET(mask, val)	(((u64)(val) << FIELD_SHIFT(mask)) & mask)
-#define FIELD_GET(mask, reg)	((reg & mask) >> FIELD_SHIFT(mask))
+#define BITFIELD_GET(mask, reg)	((reg & mask) >> FIELD_SHIFT(mask))
 
 /**
  * print_raw_data - print raw data to kernel log

--- a/qdma_access/qdma_context.c
+++ b/qdma_access/qdma_context.c
@@ -122,9 +122,9 @@ int qdma_write_sw_ctxt(struct qdma_dev *qdev, u16 qid, enum qdma_dir dir,
 	cmd.bits.op = QDMA_CTXT_CMD_OP_WR;
 	cmd.bits.qid = qdma_get_real_qid(qdev, qid);
 
-	desc_base_l = (u32)FIELD_GET(QDMA_SW_CTXT_DESC_BASE_GET_L_MASK,
+	desc_base_l = (u32)BITFIELD_GET(QDMA_SW_CTXT_DESC_BASE_GET_L_MASK,
 				     ctxt->desc_base);
-	desc_base_h = (u32)FIELD_GET(QDMA_SW_CTXT_DESC_BASE_GET_H_MASK,
+	desc_base_h = (u32)BITFIELD_GET(QDMA_SW_CTXT_DESC_BASE_GET_H_MASK,
 				     ctxt->desc_base);
 
 	data[num_words++] =
@@ -256,9 +256,9 @@ int qdma_write_pfch_ctxt(struct qdma_dev *qdev, u16 qid,
 	cmd.bits.op = QDMA_CTXT_CMD_OP_WR;
 	cmd.bits.qid = qdma_get_real_qid(qdev, qid);
 
-	sw_crdt_l = (u32)FIELD_GET(QDMA_PFCH_CTXT_SW_CRDT_GET_L_MASK,
+	sw_crdt_l = (u32)BITFIELD_GET(QDMA_PFCH_CTXT_SW_CRDT_GET_L_MASK,
 				   ctxt->sw_crdt);
-	sw_crdt_h = (u32)FIELD_GET(QDMA_PFCH_CTXT_SW_CRDT_GET_H_MASK,
+	sw_crdt_h = (u32)BITFIELD_GET(QDMA_PFCH_CTXT_SW_CRDT_GET_H_MASK,
 				   ctxt->sw_crdt);
 
 	data[num_words++] =
@@ -316,13 +316,13 @@ int qdma_write_cmpl_ctxt(struct qdma_dev *qdev, u16 qid,
 	cmd.bits.op = QDMA_CTXT_CMD_OP_WR;
 	cmd.bits.qid = qdma_get_real_qid(qdev, qid);
 
-	baddr_l = (u32)FIELD_GET(QDMA_CMPL_CTXT_BADDR_GET_L_MASK,
+	baddr_l = (u32)BITFIELD_GET(QDMA_CMPL_CTXT_BADDR_GET_L_MASK,
 				 ctxt->baddr);
-	baddr_h = (u32)FIELD_GET(QDMA_CMPL_CTXT_BADDR_GET_H_MASK,
+	baddr_h = (u32)BITFIELD_GET(QDMA_CMPL_CTXT_BADDR_GET_H_MASK,
 				 ctxt->baddr);
-	pidx_l = (u32)FIELD_GET(QDMA_CMPL_CTXT_PIDX_GET_L_MASK,
+	pidx_l = (u32)BITFIELD_GET(QDMA_CMPL_CTXT_PIDX_GET_L_MASK,
 				ctxt->pidx);
-	pidx_h = (u32)FIELD_GET(QDMA_CMPL_CTXT_PIDX_GET_H_MASK,
+	pidx_h = (u32)BITFIELD_GET(QDMA_CMPL_CTXT_PIDX_GET_H_MASK,
 				ctxt->pidx);
 
 	data[num_words++] =

--- a/qdma_access/qdma_export.c
+++ b/qdma_access/qdma_export.c
@@ -54,8 +54,8 @@ void qdma_unpack_wb_stat(struct qdma_wb_stat *stat, u8 *data)
 
 	dw = (u64 *)data;
 
-	stat->pidx = FIELD_GET(QDMA_WB_STAT_DW_PIDX_MASK, *dw);
-	stat->cidx = FIELD_GET(QDMA_WB_STAT_DW_CIDX_MASK, *dw);
+	stat->pidx = BITFIELD_GET(QDMA_WB_STAT_DW_PIDX_MASK, *dw);
+	stat->cidx = BITFIELD_GET(QDMA_WB_STAT_DW_CIDX_MASK, *dw);
 }
 
 void qdma_unpack_c2h_cmpl(struct qdma_c2h_cmpl *cmpl, u8 *data)
@@ -67,10 +67,10 @@ void qdma_unpack_c2h_cmpl(struct qdma_c2h_cmpl *cmpl, u8 *data)
 
 	dw = (u64 *)data;
 
-	cmpl->color = FIELD_GET(QDMA_C2H_CMPL_DW_COLOR_MASK, *dw);
-	cmpl->err = FIELD_GET(QDMA_C2H_CMPL_DW_ERR_MASK, *dw);
-	cmpl->pkt_len = FIELD_GET(QDMA_C2H_CMPL_DW_PKT_LEN_MASK, *dw);
-	cmpl->pkt_id = FIELD_GET(QDMA_C2H_CMPL_DW_PKT_ID_MASK, *dw);
+	cmpl->color = BITFIELD_GET(QDMA_C2H_CMPL_DW_COLOR_MASK, *dw);
+	cmpl->err = BITFIELD_GET(QDMA_C2H_CMPL_DW_ERR_MASK, *dw);
+	cmpl->pkt_len = BITFIELD_GET(QDMA_C2H_CMPL_DW_PKT_LEN_MASK, *dw);
+	cmpl->pkt_id = BITFIELD_GET(QDMA_C2H_CMPL_DW_PKT_ID_MASK, *dw);
 }
 
 void qdma_unpack_c2h_cmpl_stat(struct qdma_c2h_cmpl_stat *stat, u8 *data)
@@ -82,9 +82,9 @@ void qdma_unpack_c2h_cmpl_stat(struct qdma_c2h_cmpl_stat *stat, u8 *data)
 
 	dw = (u64 *)data;
 
-	stat->pidx = FIELD_GET(QDMA_C2H_CMPL_STAT_DW_PIDX_MASK, *dw);
-	stat->cidx = FIELD_GET(QDMA_C2H_CMPL_STAT_DW_CIDX_MASK, *dw);
-	stat->color = FIELD_GET(QDMA_C2H_CMPL_STAT_DW_COLOR_MASK, *dw);
+	stat->pidx = BITFIELD_GET(QDMA_C2H_CMPL_STAT_DW_PIDX_MASK, *dw);
+	stat->cidx = BITFIELD_GET(QDMA_C2H_CMPL_STAT_DW_CIDX_MASK, *dw);
+	stat->color = BITFIELD_GET(QDMA_C2H_CMPL_STAT_DW_COLOR_MASK, *dw);
 	stat->intr_state =
-		FIELD_GET(QDMA_C2H_CMPL_STAT_DW_INTR_STATE_MASK, *dw);
+		BITFIELD_GET(QDMA_C2H_CMPL_STAT_DW_INTR_STATE_MASK, *dw);
 }


### PR DESCRIPTION
* Mainly remove, or start using some unused variables - clang is stricter than gcc with unused variables and fail to compile.
* The lack of using the `ret` var in function `xocl_drvinst_set_offline` is a bug, as this function would always return 0 even when failing and should have returned `-EINODEV`.
* Added a new with-clang make target that compiles

Depends on PR #52