### PR TITLE
Fix KDIR delcaration in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ BASE_OBJS := $(patsubst $(srcdir)/%.c,%.o,$(wildcard $(srcdir)/*.c $(srcdir)/*/*
 onic-objs = $(BASE_OBJS)
 ccflags-y = -O3 -Wall -Werror -I$(srcdir)/qdma_access -I$(srcdir)/hwmon -I$(srcdir)
 
-KDIR ?= /lib/modules/$(shell uname -r)/build
+KDIR ?= /lib/modules/$(KERNEL_VERS)/build
 
 all:
 	make -C $(KDIR) M=$(PWD) modules


### PR DESCRIPTION
Simple cleanup I noticed while building it in a container. From commit message:

```
`KDIR` was calling `$(shell uname -r)`, instead of using `KERNEL_VERS`. This also
makes it consistent with other paths used in the makefile
```